### PR TITLE
missing link library -lrt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ ifeq ($(platform), unix)
    ifneq ($(shell uname -p | grep -E '((i.|x)86|amd64)'),)
       IS_X86 = 1
    endif
-   LDFLAGS += $(PTHREAD_FLAGS)
+   LDFLAGS += $(PTHREAD_FLAGS) -lrt
    FLAGS += $(PTHREAD_FLAGS) -DHAVE_MKDIR
 else ifeq ($(platform), osx)
    TARGET := $(TARGET_NAME).dylib


### PR DESCRIPTION
needed by rthreads.c (on linux)