### PR TITLE
Horizontal Overscan (needs to be made optional)

### DIFF
--- a/mednafen/pce_fast/vdc.cpp
+++ b/mednafen/pce_fast/vdc.cpp
@@ -410,7 +410,7 @@ DECLFW(VDC_Write)
 static INLINE void CalcStartEnd(const vdc_t *vdc, uint32 &start, uint32 &end)
 {
    //static const unsigned int ClockModeWidths[3] = { 288, 384, 576 };
-   static const unsigned int ClockPixelWidths[3] = { 341, 455, 682 };
+   static const unsigned int ClockPixelWidths[3] = { 352, 455, 682 };
 
    start = (M_vdc_HDS + 1) * 8;
    // Semi-hack for Asuka 120%
@@ -439,6 +439,12 @@ static INLINE void CalcStartEnd(const vdc_t *vdc, uint32 &start, uint32 &end)
    // For: alignment space when correct_aspect == 0
    end += 128;
    start += 128;
+   
+   // For 352 width instead of 341 alignement
+   if(vce.dot_clock == 1){
+	   end += 6;
+	   start += 6;
+   }
 }
 
 #define CB_EXL(n) (((n) << 4) | ((n) << 12) | ((n) << 20) | ((n) << 28) | ((n) << 36) | ((n) << 44) | ((n) << 52) | ((n) << 60))
@@ -850,8 +856,8 @@ void VDC_RunFrame(EmulateSpecStruct *espec, bool IsHES)
       if(!skip)
       {
          static const int ws[2][3] = {
-            { 341, 341, 682 },
-            { 256, 341, 512 }
+            { 352, 352, 682 },
+            { 256, 352, 512 }
          };
 
          DisplayRect->x = 0;


### PR DESCRIPTION
Display 352 pixels width instead of 341 for games using this mode.
That's something that exists in mednafen PCE "not Fast" but not in this Fast version.

Ideally would need to be made a core option "Horizontal Overscan" ON/OFF but I don't know how to write that.
That's here if anyone feels like it. :)