### PR TITLE
libretro: Add install and uninstall make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ NEED_CRC32 = 1
 WANT_NEW_API = 1
 CORE_DEFINE := -DWANT_PCE_FAST_EMU -DWANT_STEREO_SOUND
 
+prefix := /usr
+libdir := $(prefix)/lib
+
+LIBRETRO_INSTALL_DIR := libretro
 TARGET_NAME := mednafen_pce_fast
 GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
 ifneq ($(GIT_VERSION)," unknown")
@@ -346,5 +350,11 @@ endif
 
 clean:
 	rm -f $(TARGET) $(OBJECTS)
+
+install:
+	install -D -m 755 $(TARGET) $(DESTDIR)$(libdir)/$(LIBRETRO_INSTALL_DIR)/$(TARGET)
+
+uninstall:
+	rm $(DESTDIR)$(libdir)/$(LIBRETRO_INSTALL_DIR)/$(TARGET)
 
 .PHONY: clean


### PR DESCRIPTION
So we can properly install the core system wide.