### PR TITLE
Fix CHD leadout calculation

### DIFF
--- a/mednafen/cdrom/CDAccess_CHD.cpp
+++ b/mednafen/cdrom/CDAccess_CHD.cpp
@@ -161,7 +161,7 @@ bool CDAccess_CHD::Load(const std::string &path, bool image_memcache)
     plba += frames - Tracks[NumTracks].pregap_dv;
     plba += Tracks[NumTracks].postgap;
 
-    numsectors += frames;
+    numsectors += (NumTracks == 1) ? frames : frames + Tracks[NumTracks].pregap;
 
     toc.first_track = 1;
     toc.last_track = NumTracks;


### PR DESCRIPTION
The leadout calculation in CHD reader was wrong.
This could lead to issues reading last audio track or potential disc check issues.
This PR fixes it.

A similar PR has been pushed for beetle-pcfx-libretro core.