### PR TITLE
Fix alignment

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -220,6 +220,9 @@ static int Load(const char *name, MDFNFILE *fp)
 
   HuCLoad(GET_FDATA_PTR(fp) + headerlen, GET_FSIZE_PTR(fp) - headerlen);
 
+ if(crc = 0xfae0fc60)
+  OrderOfGriffonFix = true;
+
  return(LoadCommon());
 }
 

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -59,6 +59,8 @@ MDFNGI *MDFNGameInfo = &EmulatedPCE_Fast;
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
+extern "C" unsigned long crc32(unsigned long crc, const unsigned char *buf, unsigned int len);
+
 static PCEFast_PSG *psg = NULL;
 extern ArcadeCard *arcade_card; // Bah, lousy globals.
 
@@ -213,6 +215,8 @@ static int Load(const char *name, MDFNFILE *fp)
   PCERead[x] = PCEBusRead;
   PCEWrite[x] = PCENullWrite;
  }
+
+ uint32 crc = crc32(0, GET_FDATA_PTR(fp) + headerlen, GET_FSIZE_PTR(fp) - headerlen);
 
   HuCLoad(GET_FDATA_PTR(fp) + headerlen, GET_FSIZE_PTR(fp) - headerlen);
 

--- a/mednafen/pce_fast/vdc.cpp
+++ b/mednafen/pce_fast/vdc.cpp
@@ -812,6 +812,14 @@ void VDC_RunFrame(EmulateSpecStruct *espec, bool IsHES)
       if(!skip)
       {
          DisplayRect->x = 0;
+
+         // Order of Griffon semi-hack
+         if (OrderOfGriffonFix)
+         {
+            // Force to use specified width to fit status bar inside frame.
+            defined_width[0] = defined_width[1] = 320;
+         }
+
          DisplayRect->w = defined_width[vce.dot_clock];
       }
 

--- a/mednafen/settings.cpp
+++ b/mednafen/settings.cpp
@@ -31,6 +31,7 @@ int setting_pce_fast_adpcmvolume = 100;
 int setting_pce_fast_cdpsgvolume = 100;
 uint32_t setting_pce_fast_cdspeed = 1;
 std::string setting_pce_fast_cdbios = "syscard3.pce";
+bool OrderOfGriffonFix = false;
 
 uint64 MDFN_GetSettingUI(const char *name)
 {

--- a/mednafen/settings.h
+++ b/mednafen/settings.h
@@ -13,6 +13,7 @@ extern int setting_pce_fast_adpcmvolume;
 extern int setting_pce_fast_cdpsgvolume;
 extern uint32_t setting_pce_fast_cdspeed;
 extern std::string setting_pce_fast_cdbios;
+extern bool OrderOfGriffonFix;
 
 // This should assert() or something if the setting isn't found, since it would
 // be a totally tubular error!


### PR DESCRIPTION
This game uses different width in one frame which results in portions of the image (status bar to be exact) to be off-centered and cut at one side.
This libretro hack forces to use the specified resolution so the statusbar can fit within the display frame during such conditions.
The side-effect result though is black bars on the sides of the image with smaller dimensions(probably looks better than an image that does not fit in screen).

Game uses mostly 320 width so we use this as to not add black bars. Haven't gone far into the game to see if game uses any larger than that.

This hack is matched by crc check and should not affect other than this game.

current state:
https://imgur.com/NQBTkyk
https://imgur.com/fmyZrRv

after patch:
https://imgur.com/rlEa1BV
https://imgur.com/kcSagBi


PS:
not sure if there is already an existing implementation which handles this kind of condition.(other than probably re-scaling the image bt scanlines)

Comments, suggestions, edits are welcome.

