### PR TITLE
Add US CD bios core option

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -1227,6 +1227,11 @@ static void check_variables(void)
          setting_pce_fast_cdbios = "syscard1.pce";
       else if (strcmp(var.value, "Games Express") == 0)
          setting_pce_fast_cdbios = "gexpress.pce";
+      else if (strcmp(var.value, "System Card 3 US") == 0)
+         setting_pce_fast_cdbios = "syscard3u.pce";
+      else if (strcmp(var.value, "System Card 2 US") == 0)
+         setting_pce_fast_cdbios = "syscard2u.pce";
+      
    }
 
    var.key = "pce_nospritelimit";
@@ -1745,7 +1750,7 @@ void retro_set_environment(retro_environment_t cb)
 
    static const struct retro_variable vars[] = {
       { "pce_fast_cdimagecache", "CD Image Cache (Restart); disabled|enabled" },
-      { "pce_fast_cdbios", "CD Bios (Restart); System Card 3|Games Express|System Card 1|System Card 2" },
+      { "pce_fast_cdbios", "CD Bios (Restart); System Card 3|Games Express|System Card 1|System Card 2|System Card 2 US|System Card 3 US" },
       { "pce_nospritelimit", "No Sprite Limit (Restart); disabled|enabled" },
       { "pce_ocmultiplier", "CPU Overclock Multiplier (Restart); 1|2|3|4|5|6|7|8|9|10|20|30|40|50" },
       { "pce_hoverscan", "Horizontal Overscan (352 Width Mode Only); 352|300|302|304|306|308|310|312|314|316|318|320|322|324|326|328|330|332|334|336|338|340|342|344|346|348|350" },


### PR DESCRIPTION
This lets you have japan and us bios, without having to replace one for the other.

Not sure about naming.

Reference: https://tcrf.net/TurboGrafx-CD_System_Card