### PR TITLE
fix libretro fbo

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -1022,8 +1022,7 @@ void update_geometry(unsigned width, unsigned height)
 {
    struct retro_system_av_info system_av_info;
 
-   system_av_info.geometry.base_width = width;
-   system_av_info.geometry.base_height = height;
+   retro_get_system_av_info(&system_av_info);
    system_av_info.geometry.aspect_ratio = get_aspect_ratio(width, height);
 
    environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &system_av_info);


### PR DESCRIPTION
avoid random uninit values