### PR TITLE
Silence warnings and avoid undefined behavior

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -1187,7 +1187,7 @@ static void set_volume (uint32_t *ptr, unsigned number)
 
 #define MAX_PLAYERS 5
 #define MAX_BUTTONS 15
-static uint8_t input_buf[MAX_PLAYERS][2] = {0};
+static uint8_t input_buf[MAX_PLAYERS][2] = {};
 
 // Array to keep track of whether a given player's button is turbo
 static int turbo_enable[MAX_PLAYERS][MAX_BUTTONS] = {};

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -81,8 +81,6 @@ uint8 ROMSpace[0x88 * 8192 + 8192];	// + 8192 for PC-as-pointer safety padding
 uint8 BaseRAM[32768 + 8192]; // 8KB for PCE, 32KB for Super Grafx // + 8192 for PC-as-pointer safety padding
 
 uint8 PCEIODataBuffer;
-readfunc PCERead[0x100];
-writefunc PCEWrite[0x100];
 
 static DECLFR(PCEBusRead)
 {
@@ -97,7 +95,7 @@ static DECLFW(PCENullWrite)
 
 static DECLFR(BaseRAMRead)
 {
- return((BaseRAM - (0xF8 * 8192))[A]);
+ return BaseRAM[(size_t)A - (0xF8 * 8192)];
 }
 
 static DECLFR(BaseRAMRead_Mirrored)
@@ -107,7 +105,7 @@ static DECLFR(BaseRAMRead_Mirrored)
 
 static DECLFW(BaseRAMWrite)
 {
- (BaseRAM - (0xF8 * 8192))[A] = V;
+ BaseRAM[(size_t)A - (0xF8 * 8192)] = V;
 }
 
 static DECLFW(BaseRAMWrite_Mirrored)
@@ -191,7 +189,6 @@ bool PCE_InitCD(void)
  return(PCECD_Init(&cd_settings, PCECDIRQCB, PCE_MASTER_CLOCK, pce_overclocked, &sbuf[0], &sbuf[1]));
 }
 
-
 static int LoadCommon(void);
 static void LoadCommonPre(void);
 
@@ -212,13 +209,13 @@ static int Load(const char *name, MDFNFILE *fp)
 
  for(int x = 0; x < 0x100; x++)
  {
-  PCERead[x] = PCEBusRead;
-  PCEWrite[x] = PCENullWrite;
+      HuCPU.PCERead[x] = PCEBusRead;
+      HuCPU.PCEWrite[x] = PCENullWrite;
  }
 
  uint32 crc = encoding_crc32(0, GET_FDATA_PTR(fp) + headerlen, GET_FSIZE_PTR(fp) - headerlen);
 
-  HuCLoad(GET_FDATA_PTR(fp) + headerlen, GET_FSIZE_PTR(fp) - headerlen);
+  HuCLoad(GET_FDATA_PTR(fp) + headerlen, GET_FSIZE_PTR(fp) - headerlen, crc);
 
  if(crc == 0xfae0fc60)
   OrderOfGriffonFix = true;
@@ -228,6 +225,8 @@ static int Load(const char *name, MDFNFILE *fp)
 
 static void LoadCommonPre(void)
 {
+ HuC6280_Init();
+
  // FIXME:  Make these globals less global!
  pce_overclocked = MDFN_GetSettingUI("pce_fast.ocmultiplier");
  PCE_ACEnabled = MDFN_GetSettingB("pce_fast.arcadecard");
@@ -238,11 +237,10 @@ static void LoadCommonPre(void)
  if(MDFN_GetSettingUI("pce_fast.cdspeed") > 1)
   MDFN_printf("CD-ROM speed:  %ux\n", (unsigned int)MDFN_GetSettingUI("pce_fast.cdspeed"));
 
- memset(HuCPUFastMap, 0, sizeof(HuCPUFastMap));
  for(int x = 0; x < 0x100; x++)
  {
-  PCERead[x] = PCEBusRead;
-  PCEWrite[x] = PCENullWrite;
+  HuCPU.PCERead[x] = PCEBusRead;
+  HuCPU.PCEWrite[x] = PCENullWrite;
  }
 
  MDFNMP_Init(1024, (1 << 21) / 1024);
@@ -253,23 +251,21 @@ static int LoadCommon(void)
  VDC_Init(false);
 
  {
-  PCERead[0xF8] = BaseRAMRead;
-  PCERead[0xF9] = PCERead[0xFA] = PCERead[0xFB] = BaseRAMRead_Mirrored;
+  HuCPU.PCERead[0xF8] = BaseRAMRead;
+  HuCPU.PCERead[0xF9] = HuCPU.PCERead[0xFA] = HuCPU.PCERead[0xFB] = BaseRAMRead_Mirrored;
 
-  PCEWrite[0xF8] = BaseRAMWrite;
-  PCEWrite[0xF9] = PCEWrite[0xFA] = PCEWrite[0xFB] = BaseRAMWrite_Mirrored;
+  HuCPU.PCEWrite[0xF8] = BaseRAMWrite;
+  HuCPU.PCEWrite[0xF9] = HuCPU.PCEWrite[0xFA] = HuCPU.PCEWrite[0xFB] = BaseRAMWrite_Mirrored;
 
   for(int x = 0xf8; x < 0xfb; x++)
-   HuCPUFastMap[x] = BaseRAM - x * 8192;
+   HuCPU.FastMap[x] = &BaseRAM[0];
 
-  PCERead[0xFF] = IORead;
+  HuCPU.PCERead[0xFF] = IORead;
  }
 
  MDFNMP_AddRAM(8192, 0xf8 * 8192, BaseRAM);
 
- PCEWrite[0xFF] = IOWrite;
-
- HuC6280_Init();
+ HuCPU.PCEWrite[0xFF] = IOWrite;
 
  psg = new PCEFast_PSG(&sbuf[0], &sbuf[1]);
 
@@ -480,7 +476,7 @@ static MDFNSetting PCESettings[] =
 
 uint8 MemRead(uint32 addr)
 {
- return(PCERead[(addr / 8192) & 0xFF](addr));
+ return(HuCPU.PCERead[(addr / 8192) & 0xFF](addr));
 }
 
 static const FileExtensionSpecStruct KnownExtensions[] =
@@ -569,8 +565,9 @@ static void Cleanup(void)
    HuCROM = NULL;
 }
 
-int HuCLoad(const uint8 *data, uint32 len)
+int HuCLoad(const uint8 *data, uint32 len, uint32 crc32)
 {
+ uint32 crc = 0;
  uint32 sf2_threshold = 2048 * 1024;
  uint32 sf2_required_size = 2048 * 1024 + 512 * 1024;
  uint32 m_len = (len + 8191)&~8191;
@@ -587,13 +584,11 @@ int HuCLoad(const uint8 *data, uint32 len)
  IsPopulous = 0;
  PCE_IsCD = 0;
 
-
  MDFN_printf("ROM:       %dKiB\n", (len + 1023) / 1024);
+ MDFN_printf("ROM CRC32: 0x%04x\n", crc32);
 
  if(!(HuCROM = (uint8 *)malloc(m_len)))
- {
   return(0);
- }
 
  memset(HuCROM, 0xFF, m_len);
  memcpy(HuCROM, data, (m_len < len) ? m_len : len);
@@ -622,8 +617,8 @@ int HuCLoad(const uint8 *data, uint32 len)
 
  for(int x = 0x00; x < 0x80; x++)
  {
-  HuCPUFastMap[x] = ROMSpace;
-  PCERead[x] = HuCRead;
+  HuCPU.FastMap[x] = &ROMSpace[x * 8192];
+  HuCPU.PCERead[x] = HuCRead;
  }
 
  if(!memcmp(HuCROM + 0x1F26, "POPULOUS", strlen("POPULOUS")))
@@ -638,9 +633,9 @@ int HuCLoad(const uint8 *data, uint32 len)
 
   for(int x = 0x40; x < 0x44; x++)
   {
-   HuCPUFastMap[x] = &PopRAM[(x & 3) * 8192] - x * 8192;
-   PCERead[x] = HuCRead;
-   PCEWrite[x] = HuCRAMWrite;
+   HuCPU.FastMap[x] = &PopRAM[(x & 3) * 8192];
+   HuCPU.PCERead[x] = HuCRead;
+   HuCPU.PCEWrite[x] = HuCRAMWrite;
   }
   MDFNMP_AddRAM(32768, 0x40 * 8192, PopRAM);
  }
@@ -649,8 +644,8 @@ int HuCLoad(const uint8 *data, uint32 len)
   memset(SaveRAM, 0x00, 2048);
   memcpy(SaveRAM, BRAM_Init_String, 8);    // So users don't have to manually intialize the file cabinet
                                                 // in the CD BIOS screen.
-  PCEWrite[0xF7] = SaveRAMWrite;
-  PCERead[0xF7] = SaveRAMRead;
+  HuCPU.PCEWrite[0xF7] = SaveRAMWrite;
+  HuCPU.PCERead[0xF7] = SaveRAMRead;
   MDFNMP_AddRAM(2048, 0xF7 * 8192, SaveRAM);
  }
 
@@ -660,11 +655,9 @@ int HuCLoad(const uint8 *data, uint32 len)
  {
   for(int x = 0x40; x < 0x80; x++)
   {
-   // FIXME: PCE_FAST
-   HuCPUFastMap[x] = NULL; // Make sure our reads go through our read function, and not a table lookup
-   PCERead[x] = HuCSF2Read;
+   HuCPU.PCERead[x] = HuCSF2Read;
   }
-  PCEWrite[0] = HuCSF2Write;
+  HuCPU.PCEWrite[0] = HuCSF2Write;
   MDFN_printf("Street Fighter 2 Mapper\n");
   HuCSF2Latch = 0;
  }
@@ -712,17 +705,17 @@ int HuCLoadCD(const char *bios_path)
  MDFN_printf("Arcade Card Emulation:  %s\n", PCE_ACEnabled ? "Enabled" : "Disabled");
  for(int x = 0; x < 0x40; x++)
  {
-  HuCPUFastMap[x] = ROMSpace;
-  PCERead[x] = HuCRead;
+      HuCPU.FastMap[x] = &ROMSpace[x * 8192];
+      HuCPU.PCERead[x] = HuCRead;
  }
 
  for(int x = 0x68; x < 0x88; x++)
  {
-  HuCPUFastMap[x] = ROMSpace;
-  PCERead[x] = HuCRead;
-  PCEWrite[x] = HuCRAMWrite;
+      HuCPU.FastMap[x] = &ROMSpace[x * 8192];
+      HuCPU.PCERead[x] = HuCRead;
+      HuCPU.PCEWrite[x] = HuCRAMWrite;
  }
- PCEWrite[0x80] = HuCRAMWriteCDSpecial; 	// Hyper Dyne Special hack
+   HuCPU.PCEWrite[0x80] = HuCRAMWriteCDSpecial; 	// Hyper Dyne Special hack
  MDFNMP_AddRAM(262144, 0x68 * 8192, ROMSpace + 0x68 * 8192);
 
  if(PCE_ACEnabled)
@@ -736,9 +729,8 @@ int HuCLoadCD(const char *bios_path)
 
     for(int x = 0x40; x < 0x44; x++)
     {
-       HuCPUFastMap[x] = NULL;
-       PCERead[x] = ACPhysRead;
-       PCEWrite[x] = ACPhysWrite;
+         HuCPU.PCERead[x] = ACPhysRead;
+         HuCPU.PCEWrite[x] = ACPhysWrite;
     }
  }
 
@@ -746,8 +738,8 @@ int HuCLoadCD(const char *bios_path)
  memcpy(SaveRAM, BRAM_Init_String, 8);	// So users don't have to manually intialize the file cabinet
 						// in the CD BIOS screen.
 
- PCEWrite[0xF7] = SaveRAMWrite;
- PCERead[0xF7] = SaveRAMRead;
+   HuCPU.PCEWrite[0xF7] = SaveRAMWrite;
+   HuCPU.PCERead[0xF7] = SaveRAMRead;
  MDFNMP_AddRAM(2048, 0xF7 * 8192, SaveRAM);
  return(1);
 }

--- a/mednafen/pce_fast/huc.h
+++ b/mednafen/pce_fast/huc.h
@@ -1,4 +1,4 @@
-int HuCLoad(const uint8 *data, uint32 len) MDFN_COLD;
+int HuCLoad(const uint8 *data, uint32 len, uint32 crc32) MDFN_COLD;
 int HuCLoadCD(const char *bios_path) MDFN_COLD;
 void HuC_Close(void) MDFN_COLD;
 int HuC_StateAction(StateMem *sm, int load, int data_only);

--- a/mednafen/pce_fast/huc6280.cpp
+++ b/mednafen/pce_fast/huc6280.cpp
@@ -40,9 +40,9 @@ uint8 *HuCPUFastMap[0x100];
 
 
 #ifdef HUC6280_CRAZY_VERSION
-#define LOAD_LOCALS_PC()        register uint8 *PC_local = HuCPU.PC;
+#define LOAD_LOCALS_PC()        uint8 *PC_local = HuCPU.PC;
 #else
-#define LOAD_LOCALS_PC()        register uint32 PC_local /*asm ("edi")*/ = HuCPU.PC; // asm ("edi") = HuCPU.PC;
+#define LOAD_LOCALS_PC()        uint32 PC_local /*asm ("edi")*/ = HuCPU.PC; // asm ("edi") = HuCPU.PC;
 #endif
 
 #define LOAD_LOCALS()				\

--- a/mednafen/pce_fast/huc6280.cpp
+++ b/mednafen/pce_fast/huc6280.cpp
@@ -18,8 +18,8 @@
 #include "pce.h"
 #include "vdc.h"
 
+static uint8 dummy_bank[8192 + 8192];  // + 8192 for PC-as-ptr safety padding
 HuC6280 HuCPU;
-uint8 *HuCPUFastMap[0x100];
 
 #define HU_PC              PC_local //HuCPU.PC
 #define HU_PC_base	 HuCPU.PC_base
@@ -40,7 +40,7 @@ uint8 *HuCPUFastMap[0x100];
 
 
 #ifdef HUC6280_CRAZY_VERSION
-#define LOAD_LOCALS_PC()        uint8 *PC_local = HuCPU.PC;
+#define LOAD_LOCALS_PC()        uintptr_t PC_local = HuCPU.PC;
 #else
 #define LOAD_LOCALS_PC()        uint32 PC_local /*asm ("edi")*/ = HuCPU.PC; // asm ("edi") = HuCPU.PC;
 #endif
@@ -76,10 +76,10 @@ uint8 *HuCPUFastMap[0x100];
 #endif
 
 #ifdef HUC6280_CRAZY_VERSION
- #define SetPC(value) { unsigned int tempmoo = value; HU_PC = &HuCPU.FastPageR[tempmoo >> 13][tempmoo]; 	\
+ #define SetPC(value) { unsigned int tempmoo = value; HU_PC = HuCPU.FastPageR[tempmoo >> 13] + tempmoo; 	\
 	HU_PC_base = HU_PC - tempmoo; }
  #define SetPC_EXTERNAL(value) { unsigned int tempmoo = value; 	\
-	HuCPU.PC = &HuCPU.FastPageR[tempmoo >> 13][tempmoo]; HuCPU.PC_base = HuCPU.PC - tempmoo; }
+	HuCPU.PC = HuCPU.FastPageR[tempmoo >> 13] + tempmoo; HuCPU.PC_base = HuCPU.PC - tempmoo; }
 #else
  #define SetPC(value) { HU_PC = (value); }
  #define SetPC_EXTERNAL(value) { HuCPU.PC = (value); }
@@ -104,27 +104,23 @@ uint8 *HuCPUFastMap[0x100];
 #endif
 
 #ifdef HUC6280_CRAZY_VERSION
- #define RdAtPC() (*HU_PC)
- //#define RdAtAndIncPC_16() (HU_PC += 2, *(uint16 *)(HU_PC - 2))
+ #define RdAtPC() (*(uint8*)HU_PC)
 #else
  #define RdAtPC() RdOp(HU_PC)
- //#define RdAtAndIncPC_16() (RdOp(HU_PC++) | ((RdOp(HU_PC++) << 8)))
 #endif
 
 // If we change this definition, we'll need to also fix HuC6280_StealCycle() in huc6280.h
 #define ADDCYC(x) { HuCPU.timestamp += x; }
-
-static uint8 dummy_bank[8192 + 8192];  // + 8192 for PC-as-ptr safety padding
 
 #define SET_MPR(arg_i, arg_v)				\
 {							\
  const unsigned int wmpr = arg_i, wbank = arg_v;	\
  if(wmpr == 1)						\
  {							\
-  HU_Page1 = HuCPUFastMap[wbank] ? HuCPUFastMap[wbank] + wbank * 8192 : dummy_bank;	\
+  HU_Page1 = HuCPU.FastMap[wbank];    \
  }							\
  HuCPU.MPR[wmpr] = wbank;					\
- HuCPU.FastPageR[wmpr] = HuCPUFastMap[wbank] ? (HuCPUFastMap[wbank] + wbank * 8192) - wmpr * 8192 : (dummy_bank - wmpr * 8192);	\
+ HuCPU.FastPageR[wmpr] = (uintptr_t)HuCPU.FastMap[wbank] - wmpr * 8192;        \
 }
 
 void HuC6280_SetMPR(int i, int v)
@@ -146,23 +142,28 @@ static void HuC6280_FlushMPRCache(void)
 static INLINE uint8 RdMem(unsigned int A)
 {
    uint8 wmpr = HuCPU.MPR[A >> 13];
-   return(PCERead[wmpr]((wmpr << 13) | (A & 0x1FFF)));
+ return(HuCPU.PCERead[wmpr]((wmpr << 13) | (A & 0x1FFF)));
 }
 
 static INLINE uint16 RdMem16(unsigned int A)
 {
-   return(RdMem(A) | (RdMem(A + 1) << 8));
+ uint16 ret;
+
+ ret = RdMem(A);
+ ret |= RdMem(A + 1) << 8;
+
+ return(ret);
 }
 
 static INLINE void WrMem(unsigned int A, uint8 V)
 {
    uint8 wmpr = HuCPU.MPR[A >> 13];
-   PCEWrite[wmpr]((wmpr << 13) | (A & 0x1FFF), V);
+ HuCPU.PCEWrite[wmpr]((wmpr << 13) | (A & 0x1FFF), V);
 }
 
 static INLINE uint8 RdOp(unsigned int A)
 {
-   return(HuCPU.FastPageR[A >> 13][A]);
+ return *(uint8*)(HuCPU.FastPageR[A >> 13] + A);
 }
 
 #define PUSH(V) \
@@ -243,7 +244,6 @@ static uint8 ZNTable[256];
 /*  All of the freaky arithmetic operations. */
 #define AND        HU_A&=x;X_ZN(HU_A);
 
-// FIXME:
 #define BIT        HU_P&=~V_FLAG; X_ZN_BIT(x & HU_A, x); HU_P |= x & V_FLAG;
 #define EOR        HU_A^=x;X_ZN(HU_A);
 #define ORA        HU_A|=x;X_ZN(HU_A);
@@ -322,7 +322,6 @@ static uint8 ZNTable[256];
 #define RMB(bitto)	x &= ~(1 << (bitto & 7))
 #define SMB(bitto)	x |= 1 << (bitto & 7)
 
-// FIXME
 #define TSB   { HU_P &= ~V_FLAG; X_ZN_BIT(x | HU_A, x); HU_P |= x & V_FLAG; x |= HU_A; }
 #define TRB     { HU_P &= ~V_FLAG; X_ZN_BIT(x & ~HU_A, x); HU_P |= x & V_FLAG; x &= ~HU_A; }
 #define TST	{ HU_P &= ~V_FLAG; X_ZN_BIT(x & zoomhack, x); HU_P |= x & V_FLAG; }
@@ -498,8 +497,7 @@ static const uint8 CycTable[256] =
    /*0xF0*/ 2, 7, 7, 17, 2, 4, 6, 7, 2, 5, 4, 2, 2, 5, 7, 6, 
 };
 #if 0
-static bool WillIRQOccur(void) NO_INLINE;
-static bool WillIRQOccur(void)
+static NO_INLINE bool WillIRQOccur(void)
 {
    bool ret = false;
 
@@ -519,16 +517,6 @@ static bool WillIRQOccur(void)
    return(true);
 }
 #endif
-
-void HuC6280_IRQBegin(int w)
-{
-   HU_IRQlow|=w;
-}
-
-void HuC6280_IRQEnd(int w)
-{
-   HU_IRQlow&=~w;
-}
 
 void HuC6280_Reset(void)
 {
@@ -564,21 +552,26 @@ void HuC6280_Reset(void)
 
 void HuC6280_Init(void)
 {
-   memset((void *)&HuCPU,0,sizeof(HuCPU));
-   memset(dummy_bank, 0, sizeof(dummy_bank));
+	memset(&HuCPU,0,sizeof(HuCPU));
 
 #ifdef HUC6280_LAZY_FLAGS
-
 #else
    for(int x=0; x < 256; x++)
+ {
       if(!x) ZNTable[x]=Z_FLAG;
       else if (x&0x80) ZNTable[x]=N_FLAG;
       else ZNTable[x]=0;
+ }
 #endif
+
+ for (unsigned i = 0; i < 0x100; i++)
+  HuCPU.FastMap[i] = dummy_bank;
 }
 
 void HuC6280_Power(void)
 {
+ memset(dummy_bank, 0, sizeof(dummy_bank));
+
    HuCPU.IRQlow = 0;
 
    HuCPU.A = 0;
@@ -599,7 +592,7 @@ void HuC6280_Power(void)
    for(int i = 0; i < 9; i++)
    {
       HuCPU.MPR[i] = 0;
-      HuCPU.FastPageR[i] = NULL;
+  HuCPU.FastPageR[i] = 0;
    }  
    HuC6280_Reset();
 }

--- a/mednafen/pce_fast/huc6280.h
+++ b/mednafen/pce_fast/huc6280.h
@@ -5,20 +5,22 @@
 
 #define HUC6280_LAZY_FLAGS
 
-typedef struct __HuC6280
+struct HuC6280
 {
 	#ifdef HUC6280_CRAZY_VERSION
-        uint8 *PC, *PC_base;
+        uintptr_t PC, PC_base;
 	#else
 	uint16 PC;
 	#endif
 
         uint8 A,X,Y,S,P,mooPI;
+	uint8 IRQMask, IRQMaskDelay;
 	#ifdef HUC6280_LAZY_FLAGS
  	 uint32 ZNFlags;
 	#endif
 	uint8 MPR[9];		// 8, + 1 for PC overflow from $ffff to $10000
-	uint8 *FastPageR[9];
+	uint8 timer_status;
+	uintptr_t FastPageR[9];
 	uint8 *Page1;
 	//uint8 *PAGE1_W;
 	//const uint8 *PAGE1_R;
@@ -27,8 +29,6 @@ typedef struct __HuC6280
                                    And other junk hooked on for speed reasons.*/
 	int32 timestamp;
 
-	uint8 IRQMask, IRQMaskDelay;
-	uint8 timer_status;
 	int32 timer_value, timer_load;
         int32 timer_next_timestamp;
 
@@ -42,13 +42,17 @@ typedef struct __HuC6280
 	#define IBM_TIN 5
 
 	int32 previous_next_user_event;
-} HuC6280;
+
+	uint8 *FastMap[0x100];
+
+	readfunc PCERead[0x100];
+	writefunc PCEWrite[0x100];
+};
 
 void HuC6280_Run(int32 cycles);
 void HuC6280_ResetTS(void);
 
 extern HuC6280 HuCPU;
-extern uint8 *HuCPUFastMap[0x100];
 
 #define N_FLAG  0x80
 #define V_FLAG  0x40
@@ -71,8 +75,15 @@ void HuC6280_Init(void) MDFN_COLD;
 void HuC6280_Reset(void) MDFN_COLD;
 void HuC6280_Power(void) MDFN_COLD;
 
-void HuC6280_IRQBegin(int w);
-void HuC6280_IRQEnd(int w);
+static INLINE void HuC6280_IRQBegin(int w)
+{
+    HuCPU.IRQlow |= w;
+}
+
+static INLINE void HuC6280_IRQEnd(int w)
+{
+    HuCPU.IRQlow &= ~w;
+}
 
 int HuC6280_StateAction(StateMem *sm, int load, int data_only);
 

--- a/mednafen/pce_fast/huc6280_ops.inc
+++ b/mednafen/pce_fast/huc6280_ops.inc
@@ -18,7 +18,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#define TEST_WEIRD_TFLAG(n) { if(HU_P & T_FLAG) puts("RAWR" n); }
+#define TEST_WEIRD_TFLAG(n) { /* if(HU_P & T_FLAG) puts("RAWR" n); */}
 
 case 0x00:  /* BRK */
             IncPC();

--- a/mednafen/pce_fast/pce.h
+++ b/mednafen/pce_fast/pce.h
@@ -23,8 +23,6 @@ bool PCE_InitCD(void) MDFN_COLD;
 extern bool PCE_ACEnabled; // Arcade Card emulation enabled?
 void PCE_Power(void) MDFN_COLD;
 
-extern readfunc PCERead[0x100];
-extern writefunc PCEWrite[0x100];
 extern int pce_overclocked;
 
 extern uint8 BaseRAM[32768 + 8192];


### PR DESCRIPTION
```
libretro.cpp:1190:45: warning: suggest braces around initialization of subobject [-Wmissing-braces]
static uint8_t input_buf[MAX_PLAYERS][2] = {0};
                                            ^
                                            {}
1 warning generated.
```

```
mednafen/pce_fast/huc6280.cpp:613:4: warning: 'register' storage class specifier is deprecated and incompatible with C++17 [-Wdeprecated-register]
   LOAD_LOCALS();
   ^
mednafen/pce_fast/huc6280.cpp:49:2: note: expanded from macro 'LOAD_LOCALS'
        LOAD_LOCALS_PC();                       \
        ^
mednafen/pce_fast/huc6280.cpp:43:33: note: expanded from macro 'LOAD_LOCALS_PC'
#define LOAD_LOCALS_PC()        register uint8 *PC_local = HuCPU.PC;
                                ^
1 warning generated.
```

```
libretro.cpp:263:30: warning: array subscript -2031616 is below array bounds of ‘uint8 [40960]’ {aka ‘unsigned char [40960]’} [-Warray-bounds]
    HuCPUFastMap[x] = BaseRAM - x * 8192;
                      ~~~~~~~~^~~~~~~~~~
libretro.cpp:263:30: warning: array subscript -2039808 is below array bounds of ‘uint8 [40960]’ {aka ‘unsigned char [40960]’} [-Warray-bounds]
libretro.cpp:263:30: warning: array subscript -2048000 is below array bounds of ‘uint8 [40960]’ {aka ‘unsigned char [40960]’} [-Warray-bounds]
```