### PR TITLE
Filter out device types other than JOYPAD and MOUSE.

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -1729,6 +1729,10 @@ void retro_set_controller_port_device(unsigned in_port, unsigned device)
    if (in_port > 4)
       return;
 
+   // Filter out other device types, otherwise we can
+   // accidentally skip devices like joypad+analog.
+   device &= RETRO_DEVICE_JOYPAD | RETRO_DEVICE_MOUSE;
+
    switch(device)
    {
       case RETRO_DEVICE_JOYPAD:


### PR DESCRIPTION
The device type is a bitmask, and a device can have multiple types,
for example JOYPAD+ANALOG. Since we're only interested in JOYPAD and
MOUSE here, just unset all others.