### PR TITLE
Add RS-90 target

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -267,6 +267,12 @@ libretro-build-dingux-odbeta-mips32:
     - .libretro-dingux-odbeta-mips32-make-default
     - .core-defs
 
+# RS-90 OpenDingux Beta
+libretro-build-rs90-odbeta-mips32:
+  extends:
+    - .libretro-rs90-odbeta-mips32-make-default
+    - .core-defs
+
 #################################### MISC ##################################
 # Emscripten
 libretro-build-emscripten:

--- a/Makefile
+++ b/Makefile
@@ -339,6 +339,19 @@ else ifeq ($(platform), emscripten)
    TARGET := $(TARGET_NAME)_libretro_$(platform).bc
    STATIC_LINKING = 1
 
+# RS90
+else ifeq ($(platform), rs90)
+   TARGET := $(TARGET_NAME)_libretro.so
+   CC = /opt/rs90-toolchain/usr/bin/mipsel-linux-gcc
+   CXX = /opt/rs90-toolchain/usr/bin/mipsel-linux-g++
+   AR = /opt/rs90-toolchain/usr/bin/mipsel-linux-ar
+   fpic := -fPIC
+   SHARED := -shared -Wl,--no-undefined -Wl,--version-script=link.T
+   LDFLAGS += -lrt
+   FLAGS += -fomit-frame-pointer -ffast-math -march=mips32 -mtune=mips32 -D_GNU_SOURCE
+   CXXFLAGS += -std=c++11
+   CFLAGS += -std=gnu11
+
 # GCW Zero
 else ifeq ($(platform), gcw0)
    TARGET := $(TARGET_NAME)_libretro.so


### PR DESCRIPTION
This PR adds an RS-90 build target. Many games are comfortably playable when using this core on the RS-90, provided that `Frameskip` is set to `Auto`.