### PR TITLE
Fix build problems due to removal of the Hebrew localisation

### DIFF
--- a/libretro_core_options_intl.h
+++ b/libretro_core_options_intl.h
@@ -12,6 +12,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+struct retro_core_option_v2_category option_cats_he[] = {};
+struct retro_core_option_v2_definition option_defs_he[] = {};
+struct retro_core_options_v2 options_he = {
+   option_cats_he,
+   option_defs_he
+};
 /* RETRO_LANGUAGE_AR */
 
 #define CATEGORY_VIDEO_LABEL_AR "فيديو"


### PR DESCRIPTION
The Hebrew language was erroneously removed on Crowdin - right before the sync script ran. This lead to build errors, as some requires variables suddenly became undefined. This PR replaces these variables with dummies to enable building the core again.