### PR TITLE
Add core options to default to 2 or 6 buttons controllers

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -1766,6 +1766,22 @@ static void check_variables(bool first_run)
          else if (strcmp(var.value, "System Card 2 US") == 0)
             setting_pce_fast_cdbios = "syscard2u.pce";
       }
+
+      char key[256];
+      key[0] = '\0';
+
+      var.key = key ;
+      for (int i = 0 ; i < MAX_PLAYERS ; i++)
+      {
+         snprintf(key, sizeof(key), "pce_fast_default_joypad_type_p%d", i + 1);
+         if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+         {
+            if(strcmp(var.value, "2 Buttons") == 0)
+               AVPad6Enabled[i] = false;
+            else if(strcmp(var.value, "6 Buttons") == 0)
+               AVPad6Enabled[i] = true;
+         }
+      }
    }
 
    var.key = "pce_fast_nospritelimit";

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -460,6 +460,76 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "disabled"
    },
    {
+      "pce_fast_default_joypad_type_p1",
+      "P1 Default Joypad Type",
+      NULL,
+      "Choose if port 1 joypad should be 2 or 6 buttons by default. This option is only applied when the core starts, if you want to switch while content is running, use the 'Mode Switch' button. NOTE: 6 buttons joypad can have weird behaviors in non compatible games.",
+      NULL,
+      "input",
+      {
+         { "2 Buttons", NULL },
+         { "6 Buttons", NULL },
+         { NULL, NULL},
+      },
+      "2 Buttons"
+   },
+   {
+      "pce_fast_default_joypad_type_p2",
+      "P2 Default Joypad Type",
+      NULL,
+      "Choose if port 2 joypad should be 2 or 6 buttons by default. This option is only applied when the core starts, if you want to switch while content is running, use the 'Mode Switch' button. NOTE: 6 buttons joypad can have weird behaviors in non compatible games.",
+      NULL,
+      "input",
+      {
+         { "2 Buttons", NULL },
+         { "6 Buttons", NULL },
+         { NULL, NULL},
+      },
+      "2 Buttons"
+   },
+   {
+      "pce_fast_default_joypad_type_p3",
+      "P3 Default Joypad Type",
+      NULL,
+      "Choose if port 3 joypad should be 2 or 6 buttons by default. This option is only applied when the core starts, if you want to switch while content is running, use the 'Mode Switch' button. NOTE: 6 buttons joypad can have weird behaviors in non compatible games.",
+      NULL,
+      "input",
+      {
+         { "2 Buttons", NULL },
+         { "6 Buttons", NULL },
+         { NULL, NULL},
+      },
+      "2 Buttons"
+   },
+   {
+      "pce_fast_default_joypad_type_p4",
+      "P4 Default Joypad Type",
+      NULL,
+      "Choose if port 4 joypad should be 2 or 6 buttons by default. This option is only applied when the core starts, if you want to switch while content is running, use the 'Mode Switch' button. NOTE: 6 buttons joypad can have weird behaviors in non compatible games.",
+      NULL,
+      "input",
+      {
+         { "2 Buttons", NULL },
+         { "6 Buttons", NULL },
+         { NULL, NULL},
+      },
+      "2 Buttons"
+   },
+   {
+      "pce_fast_default_joypad_type_p5",
+      "P5 Default Joypad Type",
+      NULL,
+      "Choose if port 5 joypad should be 2 or 6 buttons by default. This option is only applied when the core starts, if you want to switch while content is running, use the 'Mode Switch' button. NOTE: 6 buttons joypad can have weird behaviors in non compatible games.",
+      NULL,
+      "input",
+      {
+         { "2 Buttons", NULL },
+         { "6 Buttons", NULL },
+         { NULL, NULL},
+      },
+      "2 Buttons"
+   },
+   {
       "pce_fast_turbo_toggling",
       "Turbo Toggle",
       NULL,


### PR DESCRIPTION
Add core options to let the user chose if the joypads should be 2 or 6 buttons by default, so if you want to play a 6 buttons game, you don't have to press the "Mode Switch" every time you boot it. It's also very useful for SNES-like controllers without a "L2" button, previously you had to remap the "Mode Switch" button, return to game and press it, then remap it back, super annoying...