### PR TITLE
Add support for 16KB pages on Android.

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -34,6 +34,6 @@ LOCAL_MODULE       := retro
 LOCAL_SRC_FILES    := $(SOURCES_CXX) $(SOURCES_C)
 LOCAL_CFLAGS       := $(COREFLAGS)
 LOCAL_CXXFLAGS     := $(COREFLAGS)
-LOCAL_LDFLAGS      := -Wl,-version-script=$(CORE_DIR)/link.T
+LOCAL_LDFLAGS      := -Wl,-version-script=$(CORE_DIR)/link.T,-z,max-page-size=16384
 LOCAL_CPP_FEATURES := exceptions
 include $(BUILD_SHARED_LIBRARY)


### PR DESCRIPTION
Since last year Google is requiring every application on Google Play to support 16KB pages: https://android-developers.googleblog.com/2025/05/prepare-play-apps-for-devices-with-16kb-page-size.html

It's a tiny build script change, I've tested it locally and it's working fine.

We did a test pilot with fceumm (https://github.com/libretro/libretro-fceumm/pull/644) and now I'm creating all the PRs for the other cores.