### PR TITLE
Avoid tvOS stack overflow in PCE Fast load path

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -1539,16 +1539,27 @@ static bool MDFNI_LoadCD(const char *path, const char *ext)
 
    if(!strcasecmp(ext, "m3u"))
    {
-      M3UList file_list;
+      /*
+       * M3UList is 1 MiB (256 x 4096-byte paths). Keeping it on the
+       * stack causes retro_load_game() to overflow tvOS's 1 MiB main
+       * thread stack, even for ordinary HuCard content: the optimizer
+       * inlines this branch into the common load routine. Keep the list
+       * on the heap instead.
+       */
+      M3UList *file_list = calloc(1, sizeof(*file_list));
       unsigned i;
 
-      file_list.n = 0;
-
-      ReadM3U(&file_list, path, 0);
-
-      for(i = 0; i < file_list.n; i++)
+      if (!file_list)
       {
-         CDIF *cdif = CDIF_Open(file_list.paths[i], cdimagecache);
+         log_cb(RETRO_LOG_ERROR, "Unable to allocate M3U track list.\n");
+         return false;
+      }
+
+      ReadM3U(file_list, path, 0);
+
+      for(i = 0; i < file_list->n; i++)
+      {
+         CDIF *cdif = CDIF_Open(file_list->paths[i], cdimagecache);
 
          /* Do not push NULL interfaces into the vector: they would be
           * dereferenced by LoadCD()/PCECD_Drive_SetDisc() and deleted on
@@ -1556,13 +1567,15 @@ static bool MDFNI_LoadCD(const char *path, const char *ext)
          if (!cdif)
          {
             log_cb(RETRO_LOG_ERROR, "Error opening CD referenced by M3U: %s\n",
-                  file_list.paths[i]);
+                  file_list->paths[i]);
             continue;
          }
 
          cdifvec_push(&CDInterfaces, cdif);
          ret = true;
       }
+
+      free(file_list);
    }
    else
    {


### PR DESCRIPTION
## What changed

Move the large M3U playlist list in `MDFNI_LoadCD()` from the stack to a heap allocation, with an allocation-failure check and cleanup after track discovery.

## Why

`M3UList` is 256 entries of 4096-byte paths, approximately 1 MiB. Clang inlines the CD-loading branch into `retro_load_game()`, so the stack frame is reserved even when loading an ordinary HuCard image. On tvOS, the main thread stack is approximately 1 MiB; this caused Beetle PCE Fast to abort on a physical Apple TV before it examined the game.

The failure appeared hardware-only because the simulator has a much larger main-thread stack. The crash was initially suspected to be a dynamic-library problem, but the dylib had only system-library dependencies and the device backtrace identified the stack-size failure inside `retro_load_game()`.

## Validation

- Rebuilt device and simulator Beetle PCE Fast slices with this exact source change.
- Confirmed the generated `retro_load_game()` stack allocation drops from approximately 1 MiB to approximately 6 KiB.
- Ran the tvOS simulator smoke suite, including a real PCE load-entry probe.
- Ran the repository's full CI build and test sequence successfully.

This is a targeted portability/safety fix; it does not change the M3U parsing or CD track behavior.
